### PR TITLE
DB-50

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"
 
-addSbtPlugin("com.github.hochgi" % "sbt-cassandra-plugin"   % "0.6.2")
+addSbtPlugin("com.tuplejump.com.github.hochgi" % "sbt-cassandra"   % "1.0.0")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph"   % "0.8.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"             % "1.5.0")
 addSbtPlugin("org.scalastyle"    %% "scalastyle-sbt-plugin" % "0.8.0")


### PR DESCRIPTION
We will be using `sbt-pgp` plugin for publishing so not adding a separate mvn task. Also, removed dependency on cassandra which was added by the earlier plugin we were using for integration tests. 
